### PR TITLE
implement Validator abstraction

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -35,6 +36,7 @@ func Process(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := receipt.Validate(); err != nil {
+		log.Println("Invalid receipt:", err)
 		http.Error(w, "The receipt is invalid", http.StatusBadRequest)
 		return
 	}

--- a/receipt.go
+++ b/receipt.go
@@ -10,7 +10,6 @@ import (
 	"time"
 )
 
-
 type Receipt struct {
 	Retailer     string `json:"retailer"`
 	PurchaseDate string `json:"purchaseDate"`
@@ -29,12 +28,7 @@ type Validator func(value string) error
 type Validators []struct {
 	input    string
 	function Validator
-} 
-
-var retailerRegex    = regexp.MustCompile(`^[\w\s\-&]+$`)
-var totalRegex       = regexp.MustCompile(`^\d+\.\d{2}$`)
-var descriptionRegex = regexp.MustCompile(`^[\w\s\-]+$`)
-var priceRegex       = regexp.MustCompile(`^\d+\.\d{2}$`)
+}
 
 func validatePattern(pattern *regexp.Regexp, fieldName string) Validator {
 	return func(value string) error {
@@ -84,6 +78,10 @@ func checkValidators(validators Validators) []error {
 	}
 	return validationErrors
 }
+
+var retailerRegex = regexp.MustCompile(`^[\w\s\-&]+$`)
+var totalRegex = regexp.MustCompile(`^\d+\.\d{2}$`)
+
 /*
 Validate each part of a receipt by matching regexes and time/date values to the API spec
 */
@@ -101,7 +99,7 @@ func (r *Receipt) Validate() error {
 	if len(r.Items) < 1 {
 		validationErrors = append(validationErrors, errors.New("receipt needs at least one item"))
 	}
-	
+
 	for _, item := range r.Items {
 		if err := item.Validate(); err != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("invalid item [%v]. Error: %s", item.ShortDescription, err))
@@ -110,6 +108,9 @@ func (r *Receipt) Validate() error {
 
 	return combineErrors(validationErrors)
 }
+
+var descriptionRegex = regexp.MustCompile(`^[\w\s\-]+$`)
+var priceRegex = regexp.MustCompile(`^\d+\.\d{2}$`)
 
 /*
 Validate an item with in a receipt by matching regexes to the API spec

--- a/receipt.go
+++ b/receipt.go
@@ -47,6 +47,10 @@ func (ve validationErrors) isEmpty() bool {
 	return (len(ve.errs) == 0)
 }
 
+func (ve *validationErrors) add(err error) {
+	ve.errs = append(ve.errs, err)
+}
+
 func validatePattern(pattern *regexp.Regexp, fieldName string) Validator {
 	return func(value string) error {
 		if !pattern.MatchString(value) {
@@ -78,7 +82,7 @@ func checkValidators(validators Validators) validationErrors {
 	var validationErrors validationErrors
 	for _, v := range validators {
 		if err := v.function(v.input); err != nil {
-			validationErrors.errs = append(validationErrors.errs, err)
+			validationErrors.add(err)
 		}
 	}
 	return validationErrors
@@ -102,12 +106,12 @@ func (r *Receipt) Validate() error {
 	validationErrors := checkValidators(validators)
 
 	if len(r.Items) < 1 {
-		validationErrors.errs = append(validationErrors.errs, errors.New("receipt needs at least one item"))
+		validationErrors.add(errors.New("receipt needs at least one item"))
 	}
 
 	for _, item := range r.Items {
 		if err := item.Validate(); err != nil {
-			validationErrors.errs = append(validationErrors.errs, fmt.Errorf("invalid item [%v]. Error: %s", item.ShortDescription, err))
+			validationErrors.add(fmt.Errorf("invalid item [%v]. Error: %s", item.ShortDescription, err))
 		}
 	}
 
@@ -131,7 +135,7 @@ func (i *Item) Validate() error {
 	}
 
 	validationErrors := checkValidators(validators)
-	
+
 	if validationErrors.isEmpty() {
 		return nil
 	}

--- a/receipt.go
+++ b/receipt.go
@@ -10,6 +10,7 @@ import (
 	"time"
 )
 
+
 type Receipt struct {
 	Retailer     string `json:"retailer"`
 	PurchaseDate string `json:"purchaseDate"`
@@ -23,39 +24,91 @@ type Item struct {
 	Price            string `json:"price"`
 }
 
+type Validator func(value string) error
+
+type Validators []struct {
+	input    string
+	function Validator
+} 
+
+var retailerRegex    = regexp.MustCompile(`^[\w\s\-&]+$`)
+var totalRegex       = regexp.MustCompile(`^\d+\.\d{2}$`)
+var descriptionRegex = regexp.MustCompile(`^[\w\s\-]+$`)
+var priceRegex       = regexp.MustCompile(`^\d+\.\d{2}$`)
+
+func validatePattern(pattern *regexp.Regexp, fieldName string) Validator {
+	return func(value string) error {
+		if !pattern.MatchString(value) {
+			return fmt.Errorf("invalid %s: %s", fieldName, value)
+		}
+		return nil
+	}
+}
+
+func validateDate(fieldName string) Validator {
+	return func(value string) error {
+		if _, err := time.Parse("2006-01-02", value); err != nil {
+			return fmt.Errorf("invalid %s: %s", fieldName, value)
+		}
+		return nil
+	}
+}
+
+func validateTime(fieldName string) Validator {
+	return func(value string) error {
+		if _, err := time.Parse("15:04", value); err != nil {
+			return fmt.Errorf("invalid %s: %s", fieldName, value)
+		}
+		return nil
+	}
+}
+
+func combineErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	var sb strings.Builder
+	for _, err := range errs {
+		sb.WriteString(err.Error())
+		sb.WriteString("\n")
+	}
+	return errors.New(sb.String())
+}
+
+func checkValidators(validators Validators) []error {
+	var validationErrors []error
+	for _, v := range validators {
+		if err := v.function(v.input); err != nil {
+			validationErrors = append(validationErrors, err)
+		}
+	}
+	return validationErrors
+}
 /*
 Validate each part of a receipt by matching regexes and time/date values to the API spec
 */
 func (r *Receipt) Validate() error {
 
-	retailerPattern := `^[\w\s\-&]+$`
-	if !regexp.MustCompile(retailerPattern).MatchString(r.Retailer) {
-		return fmt.Errorf("invalid retailer: %s", r.Retailer)
+	validators := Validators{
+		{r.Retailer, validatePattern(retailerRegex, "retailer")},
+		{r.PurchaseDate, validateDate("purchaseDate")},
+		{r.PurchaseTime, validateTime("purchaseTime")},
+		{r.Total, validatePattern(totalRegex, "total")},
 	}
 
-	if _, err := time.Parse("2006-01-02", r.PurchaseDate); err != nil {
-		return fmt.Errorf("invalid purchaseDate: %s", r.PurchaseDate)
-	}
-
-	if _, err := time.Parse("15:04", r.PurchaseTime); err != nil {
-		return fmt.Errorf("invalid purchaseTime: %s", r.PurchaseTime)
-	}
-
-	totalPattern := `^\d+\.\d{2}$`
-	if !regexp.MustCompile(totalPattern).MatchString(r.Total) {
-		return fmt.Errorf("invalid total: %s", r.Total)
-	}
+	validationErrors := checkValidators(validators)
 
 	if len(r.Items) < 1 {
-		return errors.New("receipt must have at least one item")
+		validationErrors = append(validationErrors, errors.New("receipt needs at least one item"))
 	}
+	
 	for _, item := range r.Items {
 		if err := item.Validate(); err != nil {
-			return fmt.Errorf("invalid item %v", item)
+			validationErrors = append(validationErrors, fmt.Errorf("invalid item [%v]. Error: %s", item.ShortDescription, err))
 		}
 	}
 
-	return nil
+	return combineErrors(validationErrors)
 }
 
 /*
@@ -63,17 +116,12 @@ Validate an item with in a receipt by matching regexes to the API spec
 */
 func (i *Item) Validate() error {
 
-	descriptionPattern := `^[\w\s\-]+$`
-	if !regexp.MustCompile(descriptionPattern).MatchString(i.ShortDescription) {
-		return fmt.Errorf("invalid shortDescription: %s", i.ShortDescription)
+	validators := Validators{
+		{i.ShortDescription, validatePattern(descriptionRegex, "shortDescription")},
+		{i.Price, validatePattern(priceRegex, "price")},
 	}
 
-	pricePattern := `^\d+\.\d{2}$`
-	if !regexp.MustCompile(pricePattern).MatchString(i.Price) {
-		return fmt.Errorf("invalid price: %s", i.Price)
-	}
-
-	return nil
+	return combineErrors(checkValidators(validators))
 }
 
 /*


### PR DESCRIPTION
- compile regexes once instead of every time we validate
- abstract validation/validators (applicative functor vs monadic error handling) so that multiple errors can be returned/logged during validation instead of just failing the second one field is bad